### PR TITLE
Use more descriptive default labels for known bootloader entries

### DIFF
--- a/po/LINGUAS
+++ b/po/LINGUAS
@@ -1,9 +1,0 @@
-es
-fr
-hu
-it
-nl
-ru
-tr
-fa
-pt_BR

--- a/po/example.pot
+++ b/po/example.pot
@@ -16,22 +16,26 @@ msgstr ""
 "Content-Type: text/plain; charset=CHARSET\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: extension.js:118
 msgid "More..."
 msgstr ""
 
-#: extension.js:237
 msgid "Cancel"
 msgstr ""
 
-#: extension.js:170
 msgid "Restart"
 msgstr ""
 
-#: extension.js:85
+msgid "Windows $1"
+msgstr ""
+
+msgid "OSX $1"
+msgstr ""
+
+msgid "EFI Shell"
+msgstr ""
+
 msgid "UEFI Firmware"
 msgstr ""
 
-#: extension.js:179
 msgid "Select a boot-loader entry for next restart."
 msgstr ""


### PR DESCRIPTION
Basically just a couple of extra hardcoded RegExes for some preset boot IDs:
https://systemd.io/BOOT_LOADER_INTERFACE/#boot-loader-entry-identifiers

I've also added them to the translation tables because I can, but I'm not sure they really need translation.